### PR TITLE
Fix for "Trailing whitespace" jshint error in grunt-watch task

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -43,7 +43,7 @@ module.exports = function (grunt) {
             compass: {
                 files: ['<%%= yeoman.app %>/_/css/**/*.{scss,sass}'], //Watch these files, and...
                 tasks: ['compass:server'] //run this operation when the files change.
-            },<% } else if (userOpts.css == 'sass') { %> 
+            },<% } else if (userOpts.css == 'sass') { %>
             sass: {
                 files: ['<%%= yeoman.app %>/_/css/**/*.{scss,sass}'], //Watch these files, and...
                 tasks: ['sass:server'] //run this operation when the files change.


### PR DESCRIPTION
Reproducible with default “yo php” configuration.
Error listed below line.

———————————————————

Running "jshint:all" (jshint) task
Linting Gruntfile.js...ERROR
[L42:C17] W102: Trailing whitespace.
watch: {

Warning: Task "jshint:all" failed. Use --force to continue.

Aborted due to warnings.